### PR TITLE
fix: Clear the current line before printing path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,8 @@ fn main() {
     let mut git_tree = git::GitTree::new(repo_path);
 
     git_tree.iter().for_each(|file_path| {
-        // TODO: Fix overlap
+        // Clear and print the current file being processed
+        print!("\r\x1B[2K");
         print!("\r {}", file_path);
         std::io::stdout().flush().unwrap();
 
@@ -71,7 +72,8 @@ fn main() {
                 repo_stats.increment_lines(&author_email, file_extension);
             });
     });
-    println!("\r");
+    // Clear the line after processing all files
+    print!("\r\x1B[2K");
 
     let sorted_authors = repo_stats.sorted_authors();
     let sorted_file_types_by_author = repo_stats.sorted_file_types_by_author();


### PR DESCRIPTION
Sorry for the noise!  
I couldn't sort out how to preserve the original changes that used crossterm and replace the original branch in this pr:
https://github.com/martinn/repoblame/pull/7

This change only uses the Clear Line ANSI code `\x1B[2K`, and leaves `\r` to move the cursor to the beginning of the line first.

#### Ticket Link
Fixes: https://github.com/martinn/repoblame/issues/4